### PR TITLE
Control Countdown on Startpage by Nuxt-Content

### DIFF
--- a/components/ecCountdown.vue
+++ b/components/ecCountdown.vue
@@ -1,37 +1,36 @@
 <template lang="pug">
-  div(class="ec-countdown")
-    //- days
-    div(v-if="(days > 0 || keepZeros)" class="counter-days")
-      slot(name="digits" :digits="formatDigits(days)")
-        span(class="digits") {{formatDigits(days)}}
+.ec-countdown
+  //- days
+  .counter-days(v-if='days > 0 || keepZeros')
+    slot(name='digits', :digits='formatDigits(days)')
+      span.digits {{ formatDigits(days) }}
 
-      slot(name="units" :unit="dayLabel" v-if="!hideUnits")
-        span(class="unit") {{dayLabel}}
+    slot(name='units', :unit='dayLabel', v-if='!hideUnits')
+      span.unit {{ dayLabel }}
 
-    //- hours
-    div(v-if="(days > 0 || hours > 0 || keepZeros)" class="counter-hours")
-      slot(name="digits" :digits="formatDigits(hours)")
-        span(class="digits") {{formatDigits(hours)}}
+  //- hours
+  .counter-hours(v-if='days > 0 || hours > 0 || keepZeros')
+    slot(name='digits', :digits='formatDigits(hours)')
+      span.digits {{ formatDigits(hours) }}
 
-      slot(name="units" :unit="hourLabel" v-if="!hideUnits")
-        span(class="unit") {{hourLabel}}
+    slot(name='units', :unit='hourLabel', v-if='!hideUnits')
+      span.unit {{ hourLabel }}
 
-    //- minute
-    div(v-if="(days > 0 || hours > 0 || minutes > 0 || keepZeros)" class="counter-minutes")
-      slot(name="digits" :digits="formatDigits(minutes)")
-        span(class="digits") {{formatDigits(minutes)}}
+  //- minute
+  .counter-minutes(v-if='days > 0 || hours > 0 || minutes > 0 || keepZeros')
+    slot(name='digits', :digits='formatDigits(minutes)')
+      span.digits {{ formatDigits(minutes) }}
 
-      slot(name="units" :unit="minuteLabel" v-if="!hideUnits")
-        span(class="unit") {{minuteLabel}}
+    slot(name='units', :unit='minuteLabel', v-if='!hideUnits')
+      span.unit {{ minuteLabel }}
 
-    //- seconds
-    div(class="counter-seconds")
-      slot(name="digits" :digits="formatDigits(seconds)")
-        span(class="digits") {{formatDigits(seconds)}}
+  //- seconds
+  .counter-seconds
+    slot(name='digits', :digits='formatDigits(seconds)')
+      span.digits {{ formatDigits(seconds) }}
 
-      slot(name="units" :unit="secondLabel" v-if="!hideUnits")
-        span(class="unit") {{secondLabel}}
-
+    slot(name='units', :unit='secondLabel', v-if='!hideUnits')
+      span.unit {{ secondLabel }}
 </template>
 <script>
 import {
@@ -42,6 +41,7 @@ import {
   watchEffect,
   ref,
 } from '@nuxtjs/composition-api'
+import { useCurrentTime } from '~/helpers/current-time'
 
 export default defineComponent({
   props: {
@@ -56,9 +56,9 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const now = ref(null)
-    now.value = new Date()
+    const { currentTime: now } = useCurrentTime(500)
     const target = new Date(props.target)
+
     const diff = computed(() =>
       Math.trunc((target.getTime() - now.value.getTime()) / 1000)
     )
@@ -83,23 +83,6 @@ export default defineComponent({
     )
 
     const ended = computed(() => diff.value < 0)
-
-    let inter = null
-
-    onUnmounted(() => clearInterval(inter))
-    onMounted(() => {
-      if (!ended.value) {
-        inter = setInterval(() => {
-          now.value = new Date()
-        }, 500)
-
-        watchEffect(() => {
-          if (ended.value) {
-            window.location.reload()
-          }
-        })
-      }
-    })
 
     const formatDigits = (value) => {
       if (value.toString().length <= 1) {

--- a/content/anmeldephase.md
+++ b/content/anmeldephase.md
@@ -1,0 +1,6 @@
+---
+countdown:
+    # Start der nächsten Anmeldephase
+    date: '2021-11-13T12:00:00Z'
+    show: true
+---

--- a/content/anmeldephase.yml
+++ b/content/anmeldephase.yml
@@ -1,6 +1,4 @@
----
 countdown:
     # Start der nächsten Anmeldephase
     date: '2021-11-13T12:00:00Z'
     show: true
----

--- a/helpers/current-time.ts
+++ b/helpers/current-time.ts
@@ -1,0 +1,14 @@
+import { ref, onBeforeUnmount, computed } from '@nuxtjs/composition-api'
+
+export const useCurrentTime = (updateInterval: number = 1000) => {
+  const currentTime = ref(new Date())
+
+  const updateCurrentTime = () => {
+    currentTime.value = new Date()
+  }
+
+  const intervalHandle = setInterval(updateCurrentTime, updateInterval)
+  onBeforeUnmount(() => clearInterval(intervalHandle))
+
+  return { currentTime }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -126,6 +126,7 @@ import {
   useStatic,
   computed,
 } from '@nuxtjs/composition-api'
+import { useCurrentTime } from '~/helpers/current-time'
 import { supportWebp } from '../helpers/webp'
 export default defineComponent({
   setup() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,16 +8,19 @@
       min-width='100%',
       gradient='180deg, rgba(0,0,0,0.16) 0%, rgba(0,0,0,0.02) 16%, rgba(0,0,0,0.02) 80%, rgba(0,0,0,0.48) 100%'
     )
-      //- v-container.countdown.pb-0.pb-md-1.pb-lg-2.pb-xl-4
-      //-   v-row(justify='center', no-gutters)
-      //-     v-col(cols='12', md='7')
-      //-       v-card.px-3.ec-gradient.text-center.pt-4.pb-8(tile)
-      //-         span.text-h6.pb-5.white--text Die Anmeldephase hat begonnen!
-              //- ec-countdown(target='2020-11-08T14:00:00Z', keep-zeros)
-              //-   template(v-slot:digits='slotProp')
-              //-     span.text-h4.font-weight-bold.white--text(slot='digits') {{ slotProp.digits }}
-              //-   template(v-slot:units='slotProp')
-              //-     span.text-caption.text-uppercase.white--text(slot='units') {{ slotProp.unit }}
+      v-container.countdown.pb-0.pb-md-1.pb-lg-2.pb-xl-4(
+        v-if='pages.countdown.show'
+      )
+        v-row(justify='center', no-gutters)
+          v-col(cols='12', md='7')
+            v-card.px-3.ec-gradient.text-center.pt-4.pb-8(tile)
+              span.text-h6.pb-5.white--text(v-if='isCountdownFuture') Die Anmeldephase beginnt in
+              span.text-h6.pb-5.white--text(v-else) Die Anmeldephase hat begonnen!
+              ec-countdown(:target='pages.countdown.date', keep-zeros)
+                template(v-slot:digits='slotProp')
+                  span.text-h4.font-weight-bold.white--text(slot='digits') {{ slotProp.digits }}
+                template(v-slot:units='slotProp')
+                  span.text-caption.text-uppercase.white--text(slot='units') {{ slotProp.unit }}
     v-container.mb-4
       .d-flex.flex-row.justify-space-between.align-end
         h2#aktuelles Aktuelles
@@ -148,16 +151,35 @@ export default defineComponent({
         .limit(3)
         .fetch()
 
-      return { upcomingEvents, recentPosts }
+        const { countdown } = await $content('anmeldephase').fetch()
+
+        return { upcomingEvents, recentPosts, countdown }
     }, undefined, 'homeData')
 
     const pages = computed(() =>
       pages_loading.value
         ? pages_loading.value
-        : { upcomingEvents: [], recentPosts: [] }
+        : {
+            upcomingEvents: [],
+            recentPosts: [],
+            countdown: { date: undefined, show: false },
+          }
     )
 
-    return { pages, supportWebp, mail: (m) => (location.href = `mailto:${m}`) }
+    const { currentTime } = useCurrentTime()
+
+    const isCountdownFuture = computed(() => {
+      const { countdown } = pages.value
+
+      return new Date(countdown.date) > currentTime.value || false
+    })
+
+    return {
+      pages,
+      supportWebp,
+      mail: (m) => (location.href = `mailto:${m}`),
+      isCountdownFuture,
+    }
   },
   head: {
     title: 'Startseite',


### PR DESCRIPTION
control the `date` and the `visibility` of the countdown with `content/anmeldephase.md`.

Example of the frontmatter of `anmeldephase.md`
```yaml
countdown:
    date: '2021-10-22T21:15:00Z'
    show: true
```