### PR TITLE
ReadOnly-Widget for CMS

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -80,7 +80,8 @@ collections:
           widget: 'readonly',
           default: '',
           placeholder: 'keine',
-          hint: 'Nicht veränderbar über das CMS. Kann nur von *Sebastian* oder *Tobias* angepasst werden.'}
+          hint: 'Nicht veränderbar über das CMS. Kann nur von *Sebastian* oder *Tobias* angepasst werden.'
+        }
       - { label: 'Titel', name: 'title', widget: 'string' }
       - {
           label: 'Beginn',

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -5,6 +5,9 @@ backend:
   gateway_url: https://gitnet.ec-nordbund.de
   squash_merges: true
 
+# only uncommet locally!
+# local_backend: true
+
 publish_mode: editorial_workflow
 site_url: https://www.ec-nordbund.de/
 show_preview_links: true
@@ -71,7 +74,13 @@ collections:
     editor:
       preview: false
     fields:
-      - { label: 'ID', name: 'veranstaltungsID', widget: 'hidden', default: '', required: false }
+      - {
+          label: 'ID der Veranstaltung in der Verwaltung',
+          name: 'veranstaltungsID',
+          widget: 'readonly',
+          default: '',
+          placeholder: 'keine',
+          hint: 'Nicht veränderbar über das CMS. Kann nur von *Sebastian* oder *Tobias* angepasst werden.'}
       - { label: 'Titel', name: 'title', widget: 'string' }
       - {
           label: 'Beginn',

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -8,5 +8,6 @@
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
   <script crossorigin src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+  <script src="./widgets.js"></script>
 </body>
 </html>

--- a/static/admin/widgets.js
+++ b/static/admin/widgets.js
@@ -1,0 +1,45 @@
+// Custom Netlify-CMS Widgets
+// @link https://www.netlifycms.org/docs/custom-widgets/
+
+
+/**
+ * ReadOnly Widget
+ */
+; (function () {
+    const CMS = window.CMS
+    const createClass = window.createClass
+    const h = window.h
+
+    const ReadOnlyControl = createClass({
+        render: function () {
+            const placeholder = this.props.field.get('placeholder', '')
+            const value = this.props.value
+            return h('input', {
+                id: this.props.forID,
+                className: this.props.classNameWrapper,
+                type: 'text',
+                value: value || placeholder,
+                disabled: true,
+                style: {
+                    cursor: 'not-allowed',
+                    color: 'hsl(0, 0%, 56%)',
+                    backgroundColor: 'hsl(0, 0%, 92%)',
+                },
+            })
+        },
+    })
+
+    const ReadOnlyPreview = createClass({
+        render: function () {
+            return ''
+        },
+    })
+
+    const schema = {
+        properties: {
+            placeholder: { type: 'string' }
+        }
+    }
+
+    CMS.registerWidget('readonly', ReadOnlyControl, ReadOnlyPreview, schema)
+})()


### PR DESCRIPTION
Can be used for displaying the vID (readlony):
![grafik](https://user-images.githubusercontent.com/39905423/195828680-f4115771-3bc6-4f2a-8f12-7827c483a4f1.png)

Field config for this is
```yml
 - {
      label: 'ID der Veranstaltung in der Verwaltung',
      name: 'veranstaltungsID',
      widget: 'readonly',
      default: '',
      placeholder: 'keine',
      hint: 'Nicht veränderbar über das CMS. Kann nur von *Sebastian* oder *Tobias* angepasst werden.'
    }
```
